### PR TITLE
Updating packages and targeting NET6.0, NET7.0 & NET8.0

### DIFF
--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/Asos.OpenTelemetry.Exporter.EventHubs.Tests.csproj
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/Asos.OpenTelemetry.Exporter.EventHubs.Tests.csproj
@@ -1,18 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-        <PackageReference Include="Moq" Version="4.20.69" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="NUnit" Version="4.1.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/AuthenticationDelegatingHandlerTests.cs
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/AuthenticationDelegatingHandlerTests.cs
@@ -29,7 +29,7 @@ public class AuthenticationDelegatingHandlerTests
 
         var authHeader = MakeRequestAndGetAuthHeaders(httpClient);
         
-        Assert.AreEqual(expected, authHeader[0]);
+        Assert.That(expected, Is.EqualTo(authHeader[0]));
     }
     
     [Test]
@@ -48,7 +48,7 @@ public class AuthenticationDelegatingHandlerTests
         
         var authHeader = await MakeAsyncRequestAndGetAuthHeaders(httpClient);
         
-        Assert.AreEqual("Bearer test-token", authHeader[0]);
+        Assert.That("Bearer test-token", Is.EqualTo(authHeader[0]));
     }
     
     private List<string> MakeRequestAndGetAuthHeaders(HttpClient httpClient)

--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/MeterProviderExtensionsTests.cs
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/MeterProviderExtensionsTests.cs
@@ -22,6 +22,6 @@ public class MeterProviderExtensionsTests
         var builder = Sdk.CreateMeterProviderBuilder()
             .AddOtlpEventHubExporter(eventHubOptions);
 
-        Assert.IsNotNull(builder);
+        Assert.That(builder, Is.Not.Null);
     }
 }

--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/ResolveTokenProviderTests.cs
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/ResolveTokenProviderTests.cs
@@ -12,7 +12,7 @@ public class TokenResolverTests
         var provider = TokenResolver.ResolveTokenProvider(new EventHubOptions
             {AuthenticationMode = AuthenticationMode.SasKey});
 
-        Assert.IsInstanceOf<SasTokenAcquisition>(provider);
+        Assert.That(provider, Is.InstanceOf<SasTokenAcquisition>());
     }
 
     [Test]
@@ -21,7 +21,7 @@ public class TokenResolverTests
         var provider = TokenResolver.ResolveTokenProvider(new EventHubOptions
             {AuthenticationMode = AuthenticationMode.ManagedIdentity});
 
-        Assert.IsInstanceOf<JwtTokenAcquisition>(provider);
+        Assert.That(provider, Is.InstanceOf<JwtTokenAcquisition>());
     }
 
     [Test]

--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/SasTokenAcquisitionTests.cs
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/SasTokenAcquisitionTests.cs
@@ -19,7 +19,7 @@ public class SasTokenAcquisitionTests
             {AccessKey = "test", KeyName = "Sender", EventHubFqdn = "https://my-resource"});
 
         var expectedExpiry = new DateTime(2021, 06, 22, 13, 30, 00);
-        Assert.AreEqual(expectedExpiry, accessToken.ExpiresOn.DateTime);
+        Assert.That(expectedExpiry, Is.EqualTo(accessToken.ExpiresOn.DateTime));
     }
 
     [Test]
@@ -33,9 +33,8 @@ public class SasTokenAcquisitionTests
         var accessToken = tokenAcquisition.GetToken(new EventHubOptions
             {AccessKey = "test", KeyName = "Sender", EventHubFqdn = "https://my-resource", AuthenticationMode = AuthenticationMode.SasKey});
 
-        var expected =
-            "sr=https%3A%2F%2Fmy-resource&sig=9GN48obx4qmr8AnCbslsNx8nij25uqayZnK7Aur%2FjjQ%3D&se=1624368600&skn=Sender";
-        Assert.AreEqual(expected, accessToken.Token);
+        var expected = "sr=https%3A%2F%2Fmy-resource&sig=9GN48obx4qmr8AnCbslsNx8nij25uqayZnK7Aur%2FjjQ%3D&se=1624368600&skn=Sender";
+        Assert.That(expected, Is.EqualTo(accessToken.Token));
     }
     
     [Test]
@@ -49,8 +48,7 @@ public class SasTokenAcquisitionTests
         var accessToken = await tokenAcquisition.GetTokenAsync(new EventHubOptions
             {AccessKey = "test", KeyName = "Sender", EventHubFqdn = "https://my-resource"});
 
-        var expected =
-            "sr=https%3A%2F%2Fmy-resource&sig=9GN48obx4qmr8AnCbslsNx8nij25uqayZnK7Aur%2FjjQ%3D&se=1624368600&skn=Sender";
-        Assert.AreEqual(expected, accessToken.Token);
+        var expected = "sr=https%3A%2F%2Fmy-resource&sig=9GN48obx4qmr8AnCbslsNx8nij25uqayZnK7Aur%2FjjQ%3D&se=1624368600&skn=Sender";
+        Assert.That(expected, Is.EqualTo(accessToken.Token));
     }
 }

--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/TokenCacheTests.cs
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/TokenCacheTests.cs
@@ -32,7 +32,7 @@ public class TokenCacheTests
 
         var result = await _tokenCache.GetTokenAsync();
 
-        Assert.AreEqual("newtoken", result);
+        Assert.That("newtoken", Is.EqualTo(result));
     }
 
     [TestCase(-10)]
@@ -48,7 +48,7 @@ public class TokenCacheTests
 
         var result = await _tokenCache.GetTokenAsync();
 
-        Assert.AreEqual(NewToken, result);
+        Assert.That(NewToken, Is.EqualTo(result));
     }
     
     [Test]
@@ -63,6 +63,6 @@ public class TokenCacheTests
         
         var result = await _tokenCache.GetTokenAsync();
 
-        Assert.AreEqual("token-from-cache", result);
+        Assert.That("token-from-cache", Is.EqualTo(result));
     }
 }

--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.csproj
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageOutputPath>./nupkg</PackageOutputPath>
@@ -28,8 +28,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.10.3" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+        <PackageReference Include="Azure.Identity" Version="1.11.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Purpose
_Describe the problem or feature_

This pull request primarily focuses on upgrading the target framework and updating package references in the `Asos.OpenTelemetry.Exporter.EventHubs` and its test project. It also includes changes to the assertion style in the test cases across multiple files. 

Here are the most important changes grouped by their themes:

**Framework and Package Upgrades:**

* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.csproj`](diffhunk://#diff-e4efc52aef7e6b64ab57aa3313b32bbeaf5d2b751dbf0989ffa59b4b4a2456b9L4-R4): The target framework was upgraded from `net6.0` to `net6.0;net7.0;net8.0`. The versions of `Azure.Identity` and `OpenTelemetry.Exporter.OpenTelemetryProtocol` packages were also updated. [[1]](diffhunk://#diff-e4efc52aef7e6b64ab57aa3313b32bbeaf5d2b751dbf0989ffa59b4b4a2456b9L4-R4) [[2]](diffhunk://#diff-e4efc52aef7e6b64ab57aa3313b32bbeaf5d2b751dbf0989ffa59b4b4a2456b9L26-R31)
* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/Asos.OpenTelemetry.Exporter.EventHubs.Tests.csproj`](diffhunk://#diff-027db6082c6d69bba56ba5d9c232f1eee7b2ffc4ea9f9dc39e58b92da60119e9L4-R14): The target framework was upgraded from `net6.0` to `net8.0`. Additionally, the versions of `Microsoft.NET.Test.Sdk`, `Moq`, `NUnit`, and `coverlet.collector` packages were updated.

**Assertion Style Changes:**

* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/AuthenticationDelegatingHandlerTests.cs`](diffhunk://#diff-e92a51732db607f73189208057c63c3a85d923069eb2be8f377800876120b04aL32-R32): The `Assert.AreEqual` method was replaced with `Assert.That` in two test methods. [[1]](diffhunk://#diff-e92a51732db607f73189208057c63c3a85d923069eb2be8f377800876120b04aL32-R32) [[2]](diffhunk://#diff-e92a51732db607f73189208057c63c3a85d923069eb2be8f377800876120b04aL51-R51)
* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/MeterProviderExtensionsTests.cs`](diffhunk://#diff-e0977203629617a33c90d3a33f8fce012168d5d5c0f6e6e4bccfb386249a494dL25-R25): The `Assert.IsNotNull` method was replaced with `Assert.That` in one test method.
* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/ResolveTokenProviderTests.cs`](diffhunk://#diff-41d665155aae5062cc98006a017add8e632e5c202339ed7cf9117f92632dd3ceL15-R15): The `Assert.IsInstanceOf` method was replaced with `Assert.That` in two test methods. [[1]](diffhunk://#diff-41d665155aae5062cc98006a017add8e632e5c202339ed7cf9117f92632dd3ceL15-R15) [[2]](diffhunk://#diff-41d665155aae5062cc98006a017add8e632e5c202339ed7cf9117f92632dd3ceL24-R24)
* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/SasTokenAcquisitionTests.cs`](diffhunk://#diff-b673ad67951a6d7cbf4b9c8824fde36689565ae10551dd9979e4fa8dbf3616a0L22-R22): The `Assert.AreEqual` method was replaced with `Assert.That` in three test methods. [[1]](diffhunk://#diff-b673ad67951a6d7cbf4b9c8824fde36689565ae10551dd9979e4fa8dbf3616a0L22-R22) [[2]](diffhunk://#diff-b673ad67951a6d7cbf4b9c8824fde36689565ae10551dd9979e4fa8dbf3616a0L36-R37) [[3]](diffhunk://#diff-b673ad67951a6d7cbf4b9c8824fde36689565ae10551dd9979e4fa8dbf3616a0L52-R52)
* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/TokenCacheTests.cs`](diffhunk://#diff-a832e6c432e4d84cb8a668c2e57154d2bad5297a7757f2e9b5729d8d2adf02f5L35-R35): The `Assert.AreEqual` method was replaced with `Assert.That` in three test methods. [[1]](diffhunk://#diff-a832e6c432e4d84cb8a668c2e57154d2bad5297a7757f2e9b5729d8d2adf02f5L35-R35) [[2]](diffhunk://#diff-a832e6c432e4d84cb8a668c2e57154d2bad5297a7757f2e9b5729d8d2adf02f5L51-R51) [[3]](diffhunk://#diff-a832e6c432e4d84cb8a668c2e57154d2bad5297a7757f2e9b5729d8d2adf02f5L66-R66)
