### PR TITLE
Updating packages and adding Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+registries:
+  nuget:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+  
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/Asos.OpenTelemetry.Exporter.EventHubs"
+    registries:
+      - nuget
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    groups:
+      nuget:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "Moq"

--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/Asos.OpenTelemetry.Exporter.EventHubs.Tests.csproj
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/Asos.OpenTelemetry.Exporter.EventHubs.Tests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="Moq" Version="[4.17.2]" />
         <PackageReference Include="NUnit" Version="4.1.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">

--- a/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.csproj
+++ b/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.11.0" />
+        <PackageReference Include="Azure.Identity" Version="1.11.1" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     </ItemGroup>
 


### PR DESCRIPTION
This pull request primarily focuses on the configuration of the NuGet package ecosystem and updating specific package versions in the `Asos.OpenTelemetry.Exporter.EventHubs` project. The most important changes include the addition of a `dependabot.yml` file to configure automatic updates for NuGet packages, and updates to the versions of the `Moq` and `Azure.Identity` packages.

Here are the key changes:

Configuration of NuGet package ecosystem:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R21): Added a new configuration file for Dependabot to automatically update NuGet packages on a daily basis. The updates are scheduled at 09:00 in the "Europe/London" timezone. The `Moq` package has been added to the ignore list, meaning it won't be automatically updated.

Updates to package versions:

* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.Tests/Asos.OpenTelemetry.Exporter.EventHubs.Tests.csproj`](diffhunk://#diff-027db6082c6d69bba56ba5d9c232f1eee7b2ffc4ea9f9dc39e58b92da60119e9L11-R11): Updated the version of the `Moq` package from `4.20.70` to `4.17.2`.
* [`Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs/Asos.OpenTelemetry.Exporter.EventHubs.csproj`](diffhunk://#diff-e4efc52aef7e6b64ab57aa3313b32bbeaf5d2b751dbf0989ffa59b4b4a2456b9L31-R31): Updated the version of the `Azure.Identity` package from `1.11.0` to `1.11.1`.